### PR TITLE
Add GitHub Action to auto-merge Dependabot PRs

### DIFF
--- a/.github/workflows/auto-merge-dependabot.yml
+++ b/.github/workflows/auto-merge-dependabot.yml
@@ -7,12 +7,13 @@ on:
 jobs:
   auto-merge:
     runs-on: ubuntu-latest
+    # Only run this job when the PR author is the Dependabot bot
     if: github.actor == 'dependabot[bot]'
     permissions:
       contents: write
       pull-requests: write
     steps:
-      - name: Enable auto-merge for Dependabot PRs
+      - name: Enable auto-merge
         run: |
           PR_URL="${{ github.event.pull_request.html_url }}"
           gh pr merge --auto --merge "$PR_URL"

--- a/.github/workflows/auto-merge-dependabot.yml
+++ b/.github/workflows/auto-merge-dependabot.yml
@@ -1,0 +1,20 @@
+name: Auto-merge Dependabot PRs
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+
+jobs:
+  auto-merge:
+    runs-on: ubuntu-latest
+    if: github.actor == 'dependabot[bot]'
+    permissions:
+      contents: write
+      pull-requests: write
+    steps:
+      - name: Enable auto-merge for Dependabot PRs
+        run: |
+          PR_URL="${{ github.event.pull_request.html_url }}"
+          gh pr merge --auto --merge "$PR_URL"
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
This PR adds a GitHub Action workflow that automatically merges Dependabot pull requests when all tests are passing. The workflow:

- Triggers on pull request events
- Checks if the PR author is Dependabot
- Enables auto-merge for Dependabot PRs
- Will merge automatically once all required checks pass